### PR TITLE
Update to support MongoDB version 4.4

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -1138,6 +1138,8 @@ class MongodbDriver(AbstractDriver):
            del ss["$clusterTime"]
         if "transportSecurity" in ss:
            del ss["transportSecurity"]
+        if "metrics" in ss and "aggStageCounters" in ss["metrics"]:
+           del ss["metrics"]["aggStageCounters"]
         return ss
 
     def save_result(self, result_doc):


### PR DESCRIPTION
Removes `metrics.aggStageCounters` from server status output so as not to trigger an error in `pymongo` from `$`-prefixed key names.