### PR TITLE
PERF-2415 Fix InvalidDocument: key u'$_internalJsEmit' must not start with '$'

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -1140,6 +1140,10 @@ class MongodbDriver(AbstractDriver):
            del ss["transportSecurity"]
         if "metrics" in ss and "aggStageCounters" in ss["metrics"]:
            del ss["metrics"]["aggStageCounters"]
+        if "metrics" in ss and "operatorCounters" in ss["metrics"] and "expressions" in ss["metrics"]["operatorCounters"]:
+           del ss["metrics"]["operatorCounters"]["expressions"]
+        if "metrics" in ss and "operatorCounters" in ss["metrics"] and "match" in ss["metrics"]["operatorCounters"]:
+           del ss["metrics"]["operatorCounters"]["match"]
         return ss
 
     def save_result(self, result_doc):


### PR DESCRIPTION
This is a fix for "InvalidDocument: key u'$_internalJsEmit' must not start with '$'" (BF-21450). It handles new metrics introduced in SERVER-56422 (and others coming in SERVER-56602) the same way as other $-prefixed field were handled in get_server_status.

Here is [the patch](https://spruce.mongodb.com/version/60cd08e557e85a771190c562/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)