### PR TITLE
PERF-2676 TPCC fails for MongoDB on Atlas

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -1149,6 +1149,7 @@ class MongodbDriver(AbstractDriver):
     def save_result(self, result_doc):
         self.result_doc.update(result_doc)
         self.result_doc['after']=self.get_server_status()
+        # saving test results and server statuses ('before' and 'after') into MongoDB as a single document
         self.client.test.results.insert_one(self.result_doc)
 
 ## CLASS

--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -1149,6 +1149,6 @@ class MongodbDriver(AbstractDriver):
     def save_result(self, result_doc):
         self.result_doc.update(result_doc)
         self.result_doc['after']=self.get_server_status()
-        self.client.test.results.save(self.result_doc, check_keys=False)
+        self.client.test.results.insert_one(self.result_doc)
 
 ## CLASS

--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -1149,6 +1149,6 @@ class MongodbDriver(AbstractDriver):
     def save_result(self, result_doc):
         self.result_doc.update(result_doc)
         self.result_doc['after']=self.get_server_status()
-        self.client.test.results.save(self.result_doc)
+        self.client.test.results.save(self.result_doc, check_keys=False)
 
 ## CLASS


### PR DESCRIPTION
A short-term fix for py-tpcc to allow it to run on Atlas. See details on PERF-2676.