### PR TITLE
NotPrimaryError handling fix

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -341,9 +341,8 @@ class MongodbDriver(AbstractDriver):
             logging.error("ServerSelectionTimeoutError %d (%s) when connected to %s: ",
                           exc.code, exc.details, display_uri)
             return
-        except pymongo.errors.ConnectionFailure:
-            logging.error("ConnectionFailure %d (%s) when connected to %s: ",
-                          exc.code, exc.details, display_uri)
+        except pymongo.errors.ConnectionFailure, err:
+            logging.error("ConnectionFailure (%s) when connected to %s: ", str(err), display_uri)
             return
         except pymongo.errors.PyMongoError, err:
             logging.error("Some general error (%s) when connected to %s: ", str(err), display_uri)
@@ -1150,6 +1149,10 @@ class MongodbDriver(AbstractDriver):
         self.result_doc.update(result_doc)
         self.result_doc['after']=self.get_server_status()
         # saving test results and server statuses ('before' and 'after') into MongoDB as a single document
-        self.client.test.results.insert_one(self.result_doc)
+        try:
+           self.client.test.results.insert_one(self.result_doc)
+        except pymongo.errors.PyMongoError, err:
+           logging.error("An error (%s) occured during saving results into MongoDB", str(err))
+           print "An error (%s) occured during saving results into MongoDB" % str(err)
 
 ## CLASS

--- a/pytpcc/util/results.py
+++ b/pytpcc/util/results.py
@@ -238,7 +238,7 @@ class Results:
                 ("with", "w/o ")[driver.no_transactions],
                 driver.warehouses,
                 round(txn_new_order*60/duration), txn_new_order, duration,
-                ("off", "on")[driver.batch_writes], total_retries, str(100.0*total_retries/total_cnt)[:5],
+                ("off", "on")[driver.batch_writes], total_retries, str(total_cnt and 100.0*total_retries/total_cnt)[:5],
                 ("w/o ", "with")[driver.find_and_modify],
                 driver.read_preference,
                 u"%6.2f" % (1000* lat[int(samples/2)]), u"%6.2f" % (1000*lat[int(samples/100.0*75)]),


### PR DESCRIPTION
Setup:
Improperly configured replica set on a server-side (client will get NotPrimaryError).

Client's command:
./tpcc.py --config mconfig --warehouses 1000 --clients=100 --no-load --debug mongodb

Crash's output:
1)
"Traceback (most recent call last): File "./tpcc.py", line 244, in driver.loadConfig(config) File "/home/ubuntu/TPCC_1/py-tpcc/pytpcc/drivers/mongodbdriver.py", line 346, in loadConfig exc.code, exc.details, display_uri) UnboundLocalError: local variable 'exc' referenced before assignment"

Proper variable introduced

+ subsequent errors has been fixed:

2)
"2022-10-07 15:58:23,821 [:283] INFO : Final Results 2022-10-07 15:58:23,821 [:284] INFO : Threads: 100 Traceback (most recent call last): File "./tpcc.py", line 285, in logging.info(results.show(load_time, driver, args['clients'])) File "/home/ubuntu/TPCC_1/py-tpcc/pytpcc/util/results.py", line 241, in show ("off", "on")[driver.batch_writes], total_retries, str(100.0*total_retries/total_cnt)[:5], ZeroDivisionError: float division by zero"

ZeroDivisionError, raised by total_retries/0, handled

 3)
"File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/helpers.py", line 154, in _check_command_response raise NotPrimaryError(errmsg, response) pymongo.errors.NotPrimaryError: not primary, full error: {u'topologyVersion': {u'processId': ObjectId('634007d510aebb79c4e997b5'), u'counter': 1L}, u'code': 10107, u'ok': 0.0, u'codeName': u'NotWritablePrimary', u'errmsg': u'not primary'}

Traceback (most recent call last): File "./tpcc.py", line 288, in logging.info(results.show(load_time, driver, args['clients'])) File "/home/ubuntu/TPCC_1/py-tpcc/pytpcc/util/results.py", line 251, in show driver.save_result(result_doc) File "/home/ubuntu/TPCC_1/py-tpcc/pytpcc/drivers/mongodbdriver.py", line 1152, in save_result self.client.test.results.insert_one(self.result_doc) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/collection.py", line 708, in insert_one session=session), File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/collection.py", line 622, in _insert bypass_doc_val, session) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/collection.py", line 610, in _insert_one acknowledged, _insert_command, session) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/mongo_client.py", line 1552, in _retryable_write return self._retry_with_session(retryable, func, s, None) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/mongo_client.py", line 1438, in _retry_with_session return self._retry_internal(retryable, func, session, bulk) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/mongo_client.py", line 1470, in _retry_internal return func(session, sock_info, retryable) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/collection.py", line 605, in _insert_command retryable_write=retryable_write) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/pool.py", line 721, in command exhaust_allowed=exhaust_allowed) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/network.py", line 163, in command parse_write_concern_error=parse_write_concern_error) File "/home/ubuntu/.local/lib/python2.7/site-packages/pymongo/helpers.py", line 154, in _check_command_response raise NotPrimaryError(errmsg, response) pymongo.errors.NotPrimaryError: not primary, full error: {u'topologyVersion': {u'processId': ObjectId('634007d510aebb79c4e997b5'), u'counter': 1L}, u'code': 10107, u'ok': 0.0, u'codeName': u'NotWritablePrimary', u'errmsg': u'not primary'}"

NotPrimaryError, raised by self.client.test.results.insert_one(), handled