### PR TITLE
Add TLS/SSL encryption feature to mongodbdriver

### DIFF
--- a/pytpcc/MONGODB_EXAMPLE
+++ b/pytpcc/MONGODB_EXAMPLE
@@ -11,3 +11,7 @@ denormalize          = True
 retry_writes         = True
 # user                 = username
 # passwd               = passwd
+ssl                  = False
+ssl_certfile         = client.pem
+ssl_ca_certs         = ca.pem
+ssl_pem_passphrase   = passphrase


### PR DESCRIPTION
Introduced mongodbdriver's optional TLS/SSL (Transport Layer Security/Secure Sockets Layer) encryption feature.
Enabling/disabling the feature is controlled by the "ssl" configuration parameter and SSL certificates settings.