### PR TITLE
Fix '--reset' and '--no-load' args combination

### DIFF
--- a/pytpcc/coordinator.py
+++ b/pytpcc/coordinator.py
@@ -146,6 +146,10 @@ if __name__ == '__main__':
 
     if args['debug']: logging.getLogger().setLevel(logging.DEBUG)
 
+    ## Arguments validation
+    assert args['reset'] == False or args['no_load'] == False, \
+        "'--reset' and '--no-load' are incompatible with each other"
+
     ## Create a handle to the target client driver
     driverClass = createDriverClass(args['system'])
     assert driverClass != None, "Failed to find '%s' class" % args['system']

--- a/pytpcc/tpcc.py
+++ b/pytpcc/tpcc.py
@@ -214,6 +214,10 @@ if __name__ == '__main__':
     if args['debug']:
         logging.getLogger().setLevel(logging.DEBUG)
 
+    ## Arguments validation
+    assert args['reset'] == False or args['no_load'] == False, \
+        "'--reset' and '--no-load' are incompatible with each other"
+
     ## Create a handle to the target client driver
     driverClass = createDriverClass(args['system'])
     assert driverClass != None, "Failed to find '%s' class" % args['system']


### PR DESCRIPTION
From a logical point of view, it is not possible to specify '--reset' and '--no-load' arguments at the same time. The current py-tpcc code state allows this, causing the database to be dropped, the new database not being created, and the run phase starting on an non-existent database, resulting in a waterfall of errors. Based on this, it is proposed to introduce a check for the presence of a combination of these two arguments.


**Command:**
time ./tpcc.py --config mconfig --warehouses 1 --clients 1 --no-load --reset mongodb


**Original behavior:**
Log file:
02-10-2023 21:09:24 [<module>:242] INFO : Reseting database
02-10-2023 21:09:24 [loadConfig:314] INFO : Deleting database 'tpcc'
02-10-2023 21:09:24 [<module>:245] INFO : Initializing TPC-C benchmark using MongodbDriver
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'NEW_ORDER': Couldn't find district in new order w_id 1 d_id 7
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'NEW_ORDER': Couldn't find district in new order w_id 1 d_id 5
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'PAYMENT': Couldn't find district in payment w_id 1 d_id 10
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'NEW_ORDER': Couldn't find district in new order w_id 1 d_id 8
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'PAYMENT': Couldn't find district in payment w_id 1 d_id 5
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'NEW_ORDER': Couldn't find district in new order w_id 1 d_id 6
02-10-2023 21:09:24 [execute:072] WARNING: Failed to execute Transaction 'NEW_ORDER': Couldn't find district in new order w_id 1 d_id 7
...

Output:
None 1 4 1457.57 1 4 787 None 2023-02-10 21:09:56.928609
Traceback (most recent call last):
  File "/home/ubuntu/TPCC/py-tpcc/pytpcc/runtime/executor.py", line 68, in execute
    (val, retries) = self.driver.executeTransaction(txn, params)
  File "/home/ubuntu/TPCC/py-tpcc/pytpcc/drivers/abstractdriver.py", line 109, in executeTransaction
    result = self.doPayment(params)
  File "/home/ubuntu/TPCC/py-tpcc/pytpcc/drivers/mongodbdriver.py", line 865, in doPayment
    (value, retries) = self.run_transaction_with_retries(self._doPaymentTxn, "PAYMENT", params)
  File "/home/ubuntu/TPCC/py-tpcc/pytpcc/drivers/mongodbdriver.py", line 1117, in run_transaction_with_retries
    (ok, value) = self.run_transaction(txn_callback, s, name, params)
  File "/home/ubuntu/TPCC/py-tpcc/pytpcc/drivers/mongodbdriver.py", line 1090, in run_transaction
    return (True, txn_callback(session, params))
  File "/home/ubuntu/TPCC/py-tpcc/pytpcc/drivers/mongodbdriver.py", line 895, in _doPaymentTxn
    assert d, "Couldn't find district in payment w_id %d d_id %d" % (w_id, d_id)
AssertionError: Couldn't find district in payment w_id 1 d_id 4
Aborting some transaction with some error PAYMENT Couldn't find district in payment w_id 1 d_id 4
...


**Suggested behavior:**
Traceback (most recent call last):
  File "./tpcc.py", line 220, in <module>
    "'--reset' and '--no-load' are incompatible with each other"
AssertionError: '--reset' and '--no-load' are incompatible with each other

