### PR TITLE
BF-30706 - Remove ascii encoding on results

### DIFF
--- a/pytpcc/util/results.py
+++ b/pytpcc/util/results.py
@@ -250,5 +250,5 @@ class Results:
         if driver:
             driver.save_result(result_doc)
         print(result_doc)
-        return ret.encode('ascii', "ignore")
+        return ret
 ## CLASS


### PR DESCRIPTION
Thanks for submitting a PR to the py-tpcc repo. Please include the following fields (if relevant) prior to submitting your PR.

JIRA Ticket: [DEVPROD-3544](https://jira.mongodb.org/browse/DEVPROD-3544)

Whats Changed:
The encoding of the results message was causing issues with Python 3 as it was returning a byte string instead of the expected string. We remove this encoding to return results to their expected typing.

Patch testing results:
https://spruce.mongodb.com/version/65a7e6c33627e060877278c9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Related PRs:

https://github.com/10gen/dsi/pull/1520