### PR TITLE
PERF-5404: Fix mongodb-labs py-tpcc mongo driver to ensure it uses the latest pymongo interface

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -416,7 +416,7 @@ class MongodbDriver(AbstractDriver):
     def loadFinishDistrict(self, w_id, d_id):
         if self.denormalize:
             logging.debug("Pushing %d denormalized ORDERS records for WAREHOUSE %d DISTRICT %d into MongoDB", len(self.w_orders), w_id, d_id)
-            self.database[constants.TABLENAME_ORDERS].insert(self.w_orders.values())
+            self.database[constants.TABLENAME_ORDERS].insert_many(self.w_orders.values())
             self.w_orders.clear()
         ## IF
 


### PR DESCRIPTION
Only changed one line, from:

self.database[constants.TABLENAME_ORDERS].insert(self.w_orders.values())

to

self.database[constants.TABLENAME_ORDERS].insert_many(self.w_orders.values())

The rest is ruff stuff.

Patch test: https://spruce.mongodb.com/version/66fba91ba45ff700074bebcf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC