### PR TITLE
PERF-5973 Ensure compatibility with different versions of pymongo

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -39,6 +39,10 @@ from pprint import pformat
 from time import sleep
 import pymongo
 
+# Import TransactionOptions from pymongo.client_session or
+# pymongo.synchronous.client_session depending on the version of pymongo
+from pymongo.client_session import TransactionOptions
+
 import constants
 from .abstractdriver import AbstractDriver
 
@@ -1108,7 +1112,7 @@ class MongodbDriver(AbstractDriver):
     # Should we retry txns within the same session or start a new one?
     def run_transaction_with_retries(self, txn_callback, name, params):
         txn_retry_counter = 0
-        to = pymongo.client_session.TransactionOptions(
+        to = TransactionOptions(
             read_concern=None,
             #read_concern=pymongo.read_concern.ReadConcern("snapshot"),
             write_concern=self.write_concern,


### PR DESCRIPTION
**Jira Ticket:** [PERF-5973](https://jira.mongodb.org/browse/PERF-5973)

**Whats Changed:**  
In PyMongo 4.9, there were changes to the namespaces. Specifically, pymongo.client_session was moved to pymongo.synchronous.client_session. While PyMongo has added a compatibility module for pymongo.client_session, certain classes like TransactionOptions are no longer directly accessible. This update adds the import statements for TransactionOptions to ensure compatibility across all versions of PyMongo, allowing py-tpcc to function correctly.

**Patch testing results:**  
[Patch with pymongo 3.12.1](https://spruce.mongodb.com/version/67039e6c1e13cd00073c560b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[Patch with pymongo 4.10.1](https://spruce.mongodb.com/version/6700039acad15800072e50c9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Related PRs:**   
[PERF-5821](https://jira.mongodb.org/browse/PERF-5821) - Lists tpcc results with different versions of Python and pymongo
