### PR TITLE
PERF-6777: make agg configurable

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -197,6 +197,7 @@ class MongodbDriver(AbstractDriver):
         "denormalize":      ("If true, data will be denormalized using MongoDB schema design best practices", True),
         "notransactions":   ("If true, transactions will not be used (benchmarking only)", False),
         "findandmodify":    ("If true, all things to update will be fetched via findAndModify", True),
+        "agg":              ("If true, aggregation queries will be used", False),
         "secondary_reads":  ("If true, we will allow secondary reads", True),
         "retry_writes":     ("If true, we will enable retryable writes", True),
         "causal_consistency":  ("If true, we will perform causal reads ", True),
@@ -217,9 +218,9 @@ class MongodbDriver(AbstractDriver):
         self.client = None
         self.executed = False
         self.w_orders = {}
+        self.agg = False
         # things that are not better can't be set in config
         self.batch_writes = True
-        self.agg = False
         self.all_in_one_txn = True
         # initialize
         self.causal_consistency = False


### PR DESCRIPTION
A small change to make the agg parameter configurable.

Patch test where I run the original tpcc_majority_out_of_cache, to check that I am not breaking everything else:

https://spruce.mongodb.com/version/6836d7769136d40007aa8996/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC