### PR TITLE
PERF-6777: add missing piece to read the agg conf

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -271,6 +271,8 @@ class MongodbDriver(AbstractDriver):
         self.causal_consistency = config['causal_consistency'] == 'True'
         self.retry_writes = config['retry_writes'] == 'True'
         self.secondary_reads = config['secondary_reads'] == 'True'
+        self.agg = config['agg'] == 'True'
+
         if self.secondary_reads:
             self.read_preference = "nearest"
 


### PR DESCRIPTION
In the last PR I forgot to add the missing piece to actually read the conf.

The patch test (completed) shows that now the agg test actually runs $lookup, while the regular tpcc does not.

https://spruce.mongodb.com/version/6836f7f512d0700007c539e3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC