### PR TITLE
Fix benchant changes

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -581,7 +581,6 @@ class MongodbDriver(AbstractDriver):
 
     def loadFinish(self):
         logging.debug("Load finished")
-        self.cleanup()
 
     def executeStart(self):
         """Optional callback before the execution for each client starts"""

--- a/pytpcc/tpcc.py
+++ b/pytpcc/tpcc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------
 # Copyright (C) 2011
 # Andy Pavlo
@@ -344,7 +343,7 @@ if __name__ == '__main__':
         config = dict([(param, defaultConfig[param][1]) for param in defaultConfig.keys()])
     config['reset'] = args['reset']
     config['load'] = not args['no_load']    # True if loading, False if --no-load
-    config['execute'] = args['no_load']     # True if --no-load (execution only), False if loading
+    config['execute'] = False
     if config['reset']:
         logging.info("Reseting database")
     config['warehouses'] = args['warehouses']


### PR DESCRIPTION
This fixes --no-execute command
This fixes --client=1 command. Do not cleanup in drivers loadFinished. Cleanup is done in the tpcc.py loaderFund which calls the driver loadFinished
This fixes running pytpcc with --reset only. Which will reset, then load and then execute in a single command
