### PR TITLE
PERF-6638 Use a shared MongoClient across all worker threads

### DIFF
--- a/pytpcc/drivers/abstractdriver.py
+++ b/pytpcc/drivers/abstractdriver.py
@@ -32,6 +32,8 @@ import constants
 ## AbstractDriver
 ## ==============================================
 class AbstractDriver(object):
+    THREAD_SAFE = False
+
     def __init__(self, name, ddl):
         self.name = name
         self.driver_name = "%sDriver" % self.name.title()

--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -36,6 +36,7 @@ import json
 import logging
 import urllib
 from pprint import pformat
+import threading
 from time import sleep
 import pymongo
 from pymongo.client_session import TransactionOptions
@@ -193,6 +194,8 @@ TABLE_INDEXES = {
 ## MongodbDriver
 ## ==============================================
 class MongodbDriver(AbstractDriver):
+    THREAD_SAFE = True
+
     DEFAULT_CONFIG = {
         "uri":                ("The mongodb connection string or URI", "mongodb://localhost:27017"),
         "name":               ("Database name", "tpcc"),
@@ -210,6 +213,11 @@ class MongodbDriver(AbstractDriver):
         constants.TABLENAME_ORDERS,
         constants.TABLENAME_ORDER_LINE
     ]
+
+    _shared_client = None
+    _shared_uri = None
+    _client_lock = threading.Lock()
+    _client_refs = 0
 
     def __init__(self, ddl):
         super(MongodbDriver, self).__init__("mongodb", ddl)
@@ -304,30 +312,37 @@ class MongodbDriver(AbstractDriver):
         real_uri = uri[0:pindex]+userpassword+uri[pindex:]
         display_uri = uri[0:pindex]+usersecret+uri[pindex:]
 
-        # Retry MongoClient creation to handle DNS resolution failures when many workers connect simultaneously
-        max_retries = 10
-        for attempt in range(max_retries):
-            try:
-                self.client = pymongo.MongoClient(real_uri,
-                                                  retryWrites=self.retry_writes,
-                                                  readPreference=self.read_preference,
-                                                  readConcernLevel=self.read_concern,
-                                                  serverSelectionTimeoutMS=30000,  # 30 second timeout
-                                                  connectTimeoutMS=20000,          # 20 second connection timeout
-                                                  socketTimeoutMS=60000)           # 60 second socket timeout
-                logging.debug("MongoDB client connection established successfully")
-                break
-            except pymongo.errors.ConfigurationError as e:
-                error_msg = str(e).lower()
-                is_dns_error = 'nameserver' in error_msg or 'srv' in error_msg or 'dns' in error_msg or 'txt' in error_msg
-                if is_dns_error and attempt < max_retries - 1:
-                    delay = (attempt + 1) * 3  # 3s, 6s, 9s, 12s, 15s
-                    logging.warning("DNS resolution failed (attempt %d/%d): %s. Retrying in %d seconds...", 
-                                  attempt + 1, max_retries, str(e)[:200], delay)
-                    sleep(delay)
-                else:
-                    logging.error("Failed to create MongoDB client after %d attempts: %s", attempt + 1, str(e))
-                    raise
+        with MongodbDriver._client_lock:
+            if MongodbDriver._shared_client is None or MongodbDriver._shared_uri != real_uri:
+                max_retries = 10
+                for attempt in range(max_retries):
+                    try:
+                        MongodbDriver._shared_client = pymongo.MongoClient(
+                            real_uri,
+                            retryWrites=self.retry_writes,
+                            readPreference=self.read_preference,
+                            readConcernLevel=self.read_concern,
+                            serverSelectionTimeoutMS=30000,
+                            connectTimeoutMS=20000,
+                            socketTimeoutMS=60000)
+                        MongodbDriver._shared_uri = real_uri
+                        logging.debug("MongoDB shared client created")
+                        break
+                    except pymongo.errors.ConfigurationError as e:
+                        error_msg = str(e).lower()
+                        is_dns_error = 'nameserver' in error_msg or 'srv' in error_msg or 'dns' in error_msg or 'txt' in error_msg
+                        if is_dns_error and attempt < max_retries - 1:
+                            delay = (attempt + 1) * 3  # 3s, 6s, 9s, 12s, 15s
+                            logging.warning("DNS resolution failed (attempt %d/%d): %s. Retrying in %d seconds...",
+                                            attempt + 1, max_retries, str(e)[:200], delay)
+                            sleep(delay)
+                        else:
+                            logging.error("Failed to create MongoDB client after %d attempts: %s", attempt + 1, str(e))
+                            raise
+            else:
+                logging.debug("Reusing existing MongoDB shared client")
+            self.client = MongodbDriver._shared_client
+            MongodbDriver._client_refs += 1
         
 
         self.result_doc['before']=self.get_server_status()
@@ -572,11 +587,17 @@ class MongodbDriver(AbstractDriver):
         ## IF
 
     def cleanup(self):
-        """Close MongoDB client connection to free resources"""
-        if self.client:
-            logging.debug("Closing MongoDB client connection")
-            self.client.close()
-            self.client = None
+        """Close MongoDB shared client when the last reference is released"""
+        with MongodbDriver._client_lock:
+            if self.client:
+                MongodbDriver._client_refs -= 1
+                if MongodbDriver._client_refs <= 0:
+                    logging.debug("Closing MongoDB shared client connection")
+                    MongodbDriver._shared_client.close()
+                    MongodbDriver._shared_client = None
+                    MongodbDriver._shared_uri = None
+                    MongodbDriver._client_refs = 0
+                self.client = None
 
     def loadFinish(self):
         logging.debug("Load finished")

--- a/pytpcc/tpcc.py
+++ b/pytpcc/tpcc.py
@@ -196,6 +196,11 @@ def startLoading(driverClass, scaleParameters, args, config):
 ## loaderFunc
 ## ==============================================
 def loaderFunc(driverClass, scaleParameters, args, config, w_ids):
+    if not getattr(driverClass, 'THREAD_SAFE', False):
+        delay = random.uniform(1, 10)
+        logging.debug("Client for warehouses %s: Delaying startup by %.2f seconds to stagger connections", w_ids, delay)
+        time.sleep(delay)
+
     driver = driverClass(args['ddl'])
     assert driver != None, "Driver in loadFunc is none!"
     logging.debug("Starting client execution: %s [warehouses=%d]", driver, len(w_ids))

--- a/pytpcc/tpcc.py
+++ b/pytpcc/tpcc.py
@@ -197,6 +197,7 @@ def startLoading(driverClass, scaleParameters, args, config):
 ## ==============================================
 def loaderFunc(driverClass, scaleParameters, args, config, w_ids):
     if not getattr(driverClass, 'THREAD_SAFE', False):
+        # Add random delay (1-10 seconds) to prevent thundering herd when all clients connect simultaneously
         delay = random.uniform(1, 10)
         logging.debug("Client for warehouses %s: Delaying startup by %.2f seconds to stagger connections", w_ids, delay)
         time.sleep(delay)
@@ -246,6 +247,7 @@ def startExecution(driverClass, scaleParameters, args, config):
         else:
             r = pool.apply_async(executorFunc, (driverClass, scaleParameters, args, config, debug,))
         worker_results.append(r)
+    ## FOR
 
     if use_threads:
         pool.shutdown(wait=True)
@@ -262,6 +264,7 @@ def startExecution(driverClass, scaleParameters, args, config):
         if r == -1:
             sys.exit(1)
         total_results.append(r)
+    ## FOR
 
     return total_results
 ## DEF

--- a/pytpcc/tpcc.py
+++ b/pytpcc/tpcc.py
@@ -34,6 +34,7 @@ import argparse
 import glob
 import time
 import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
 import subprocess
 import random
 from configparser import ConfigParser
@@ -110,8 +111,9 @@ def startLoading(driverClass, scaleParameters, args, config):
     consists of 'clients' number of workers, each handling one warehouse.
     """
     clients = args['clients']
-    logging.debug("Creating client pool with %d processes", clients)
-    pool = multiprocessing.Pool(clients)
+    use_threads = getattr(driverClass, 'THREAD_SAFE', False)
+    logging.debug("Creating client pool with %d %s", clients, "threads" if use_threads else "processes")
+    pool = ThreadPoolExecutor(max_workers=clients) if use_threads else multiprocessing.Pool(clients)
 
     # Calculate total number of warehouses
     total_warehouses = scaleParameters.ending_warehouse - scaleParameters.starting_warehouse + 1
@@ -146,7 +148,10 @@ def startLoading(driverClass, scaleParameters, args, config):
         logging.debug(f"Processing warehouse {w_id} in batch {i // clients}")
 
         # Apply the loader function asynchronously for the current warehouse
-        r = pool.apply_async(loaderFunc, (driverClass, scaleParameters, args, config, [w_id]))
+        if use_threads:
+            r = pool.submit(loaderFunc, driverClass, scaleParameters, args, config, [w_id])
+        else:
+            r = pool.apply_async(loaderFunc, (driverClass, scaleParameters, args, config, [w_id]))
         loader_results.append(r)
 
         # If we've launched 'clients' workers, wait for them to complete before launching the next batch
@@ -154,7 +159,7 @@ def startLoading(driverClass, scaleParameters, args, config):
             logging.debug(f"Waiting for batch {i // clients} to complete")
             for r in loader_results:
                 try:
-                    error_message = r.get()
+                    error_message = r.result() if use_threads else r.get()
                     if error_message:
                         logging.error(f"Worker process reported error: {error_message}")
                         raise RuntimeError(f"Failed to process batch: {error_message}")
@@ -170,7 +175,7 @@ def startLoading(driverClass, scaleParameters, args, config):
         logging.debug("Waiting for the final batch to complete")
         for r in loader_results:
             try:
-                error_message = r.get()
+                error_message = r.result() if use_threads else r.get()
                 if error_message:
                     logging.error(f"Worker process reported error: {error_message}")
                     raise RuntimeError(f"Failed to process final batch: {error_message}")
@@ -178,9 +183,12 @@ def startLoading(driverClass, scaleParameters, args, config):
                 logging.error(f"Exception raised by worker process: {e}")
                 raise
 
-    pool.close()
-    logging.debug("Waiting for all loaders to finish")
-    pool.join()
+    if use_threads:
+        pool.shutdown(wait=True)
+    else:
+        pool.close()
+        logging.debug("Waiting for all loaders to finish")
+        pool.join()
     logging.info("All loading complete")
 ## DEF
 
@@ -188,12 +196,6 @@ def startLoading(driverClass, scaleParameters, args, config):
 ## loaderFunc
 ## ==============================================
 def loaderFunc(driverClass, scaleParameters, args, config, w_ids):
-    # Add random delay (1-10 seconds) to prevent thundering herd when all clients connect simultaneously
-    delay = random.uniform(1, 10)
-    logging.debug("Client for warehouses %s: Delaying startup by %.2f seconds to stagger connections", w_ids, delay)
-    time.sleep(delay)
-
-
     driver = driverClass(args['ddl'])
     assert driver != None, "Driver in loadFunc is none!"
     logging.debug("Starting client execution: %s [warehouses=%d]", driver, len(w_ids))
@@ -227,27 +229,34 @@ def loaderFunc(driverClass, scaleParameters, args, config, w_ids):
 ## startExecution
 ## ==============================================
 def startExecution(driverClass, scaleParameters, args, config):
-    logging.debug("Creating client pool with %d processes", args['clients'])
-    pool = multiprocessing.Pool(args['clients'])
+    use_threads = getattr(driverClass, 'THREAD_SAFE', False)
+    logging.debug("Creating client pool with %d %s", args['clients'], "threads" if use_threads else "processes")
+    pool = ThreadPoolExecutor(max_workers=args['clients']) if use_threads else multiprocessing.Pool(args['clients'])
     debug = logging.getLogger().isEnabledFor(logging.DEBUG)
 
     worker_results = []
     for _ in range(args['clients']):
-        r = pool.apply_async(executorFunc, (driverClass, scaleParameters, args, config, debug,))
+        if use_threads:
+            r = pool.submit(executorFunc, driverClass, scaleParameters, args, config, debug)
+        else:
+            r = pool.apply_async(executorFunc, (driverClass, scaleParameters, args, config, debug,))
         worker_results.append(r)
-    ## FOR
-    pool.close()
-    pool.join()
+
+    if use_threads:
+        pool.shutdown(wait=True)
+    else:
+        pool.close()
+        pool.join()
 
     total_results = results.Results()
     for asyncr in worker_results:
-        asyncr.wait()
-        r = asyncr.get()
+        if not use_threads:
+            asyncr.wait()
+        r = asyncr.result() if use_threads else asyncr.get()
         assert r != None, "No results object returned by thread!"
         if r == -1:
             sys.exit(1)
         total_results.append(r)
-    ## FOR
 
     return total_results
 ## DEF


### PR DESCRIPTION
**Jira Ticket:** [PERF-6638](https://jira.mongodb.org/browse/PERF-6638)

**Whats Changed:**

Use a shared `MongoClient` across all worker threads for the MongoDB driver instead of creating one client per worker process.

- Added `THREAD_SAFE = False` sentinel to `AbstractDriver`; `MongodbDriver` opts in with `THREAD_SAFE = True`
- `MongodbDriver` stores the client at the class level with reference counting so it is created once and closed only after the last worker finishes
- `tpcc.py` uses `ThreadPoolExecutor` instead of `multiprocessing.Pool` when the driver is thread-safe; all other drivers continue using multiprocessing unchanged
- Thundering-herd delay in `loaderFunc` is preserved for multiprocessing drivers and skipped for thread-safe drivers
- Requires free-threaded Python (3.13t+) with the GIL disabled; without it, `ThreadPoolExecutor` cannot run Python threads in true parallel and the shared-client approach provides no throughput benefit over multiprocessing

**Patch testing results:**

Benchmarked on Atlas M40 (MongoDB 8.0, us-east-1), 50 warehouses, 50 clients, 60 s runs, 3 runs per variant, using Python 3.14.6 free-threaded (GIL disabled).

Three variants compared: `baseline` (production + pymongo 4.17.0), `PERF-6638` (this PR + pymongo 4.17.0), and `PERF-6638 + PYTHON-5272` (this PR + pymongo 4.18.0.dev0 with TLS session caching).

| Run | baseline (tpmC) | PERF-6638 (tpmC) | PERF-6638 + PYTHON-5272 (tpmC) |
|-----|-----------------|------------------|-------------------------------|
| 1 | 5918 | 6013 | 6297 |
| 2 | 5591 | 6613 | 6539 |
| 3 | 6143 | 6360 | 6416 |
| **Average** | **5884** | **6329** | **6417** |
| **vs baseline** | | **+7.6%** | **+9.1%** |

**Related PRs:** [PYTHON-5272 Implement TLS session resumption for connections](https://github.com/mongodb/mongo-python-driver/pull/2864)