### PR TITLE
PERF-9386 make save_result catch and log error

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -1336,6 +1336,11 @@ class MongodbDriver(AbstractDriver):
         self.result_doc.update(result_doc)
         #self.result_doc['after']=self.get_server_status()
         # saving test results and server statuses ('before' and 'after') into MongoDB as a single document
-        self.client.test.results.insert_one(self.result_doc)
+        try:
+            self.client.test.results.insert_one(self.result_doc)
+        except pymongo.errors.PyMongoError as ex:
+            logging.warning(
+                "Failed to save benchmark result to MongoDB: %s (code=%s): %s",
+                type(ex).__name__, getattr(ex, "code", None), ex)
 
 ## CLASS


### PR DESCRIPTION
**Jira Ticket:** PERF-9386

**Whats Changed:**  
`save_result` calls can fail on runs where we combine py-tpcc with extra load to test availability and there is no writable primary.
DSI uses results.log file to parse results so results stored in the database are unused there, but leaving the feature in case some external tool relies on it.

Given that this is a non-critical feature, just log a warning instead of causing a hard failure.

**Patch testing results:**  
[Patch](https://spruce.corp.mongodb.com/version/6a79cedaf62c6c00073b9946/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

**Related PRs:**   
If applicable, link related PRs
