### PR TITLE
PERF-9612 Execute ORDER_STATUS transaction body only once

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -954,7 +954,6 @@ class MongodbDriver(AbstractDriver):
     ## doOrderStatus
     ## ----------------------------------------------
     def doOrderStatus(self, params):
-        (value, retries) = self.run_transaction_with_retries(self._doOrderStatusTxn, "ORDER_STATUS", params)
         return (self._doOrderStatusTxn(None, params), 0)
 
     def _doOrderStatusTxn(self, s, params):


### PR DESCRIPTION
**Jira Ticket:** PERF-9612

**What's Changed:**
`MongodbDriver.doOrderStatus()` previously executed the read-only ORDER_STATUS body **twice** per invocation — once through `run_transaction_with_retries()` (whose result and retry count were discarded) and again via a direct `session=None` call that always reported 0 retries. This doubled ORDER_STATUS reads and added pointless write-transaction overhead to ~4% of the TPC-C op mix. It now runs the body once, non-transactionally, matching the read-only STOCK_LEVEL method.

**Patch testing results:**
- `py_compile` OK; a unit-style proof (extracting the real `doOrderStatus` and counting executions against a stub `self`) shows `_doOrderStatusTxn` now runs exactly once (was twice) and no longer calls `run_transaction_with_retries`.
- sys-perf-9.0 `tpcc` (50 warehouses / 100 clients / 360 s, 3-node ARM query-engine variant): fix patch `6aa1a5aa483e9200079fede9` vs buggy baseline `6aa1cb10149ac8000789f8eb` — both pass all 12 checks. Fix shows ~halved ORDER_STATUS server read-work (~33k fewer read-executions + ~33k fewer read-only transactions per run), total throughput +0.66% at flat latency.

**Related PRs:** none
