### PR TITLE
PERF-9638: stop per-failure traceback flood in executor

### DIFF
--- a/pytpcc/runtime/executor.py
+++ b/pytpcc/runtime/executor.py
@@ -70,12 +70,18 @@ class Executor:
             except KeyboardInterrupt:
                 return -1
             except (Exception, AssertionError) as ex:
+                # One line per rejected/failed transaction. A full traceback per
+                # failure floods stdout under error storms (e.g. Atlas ingress
+                # rate-limit rejection bursts, code 462); the volume wedged the
+                # SSH channel pipe and hung every pool worker in pipe_write
+                # (BF-46197). The one-line warning already carries the driver
+                # error string. Print the traceback only when aborting the run.
                 logging.warn("Failed to execute Transaction '%s': %s" % (txn, ex))
-                traceback.print_exc(file=sys.stdout)
-                print("Aborting some transaction with some error %s %s" % (txn, ex))
                 global_result.abortTransaction(global_txn_id)
                 batch_result.abortTransaction(batch_txn_id)
-                if self.stop_on_error: raise
+                if self.stop_on_error:
+                    traceback.print_exc(file=sys.stdout)
+                    raise
                 continue
 
             if val is None:

--- a/pytpcc/runtime/executor.py
+++ b/pytpcc/runtime/executor.py
@@ -70,12 +70,6 @@ class Executor:
             except KeyboardInterrupt:
                 return -1
             except (Exception, AssertionError) as ex:
-                # One line per rejected/failed transaction. A full traceback per
-                # failure floods stdout under error storms (e.g. Atlas ingress
-                # rate-limit rejection bursts, code 462); the volume wedged the
-                # SSH channel pipe and hung every pool worker in pipe_write
-                # (BF-46197). The one-line warning already carries the driver
-                # error string. Print the traceback only when aborting the run.
                 logging.warn("Failed to execute Transaction '%s': %s" % (txn, ex))
                 global_result.abortTransaction(global_txn_id)
                 batch_result.abortTransaction(batch_txn_id)


### PR DESCRIPTION
**Jira Ticket:** PERF-9638

**Whats Changed:**  
Each rejected transaction printed a one-line WARNING plus a ~40-line traceback plus a duplicate 'Aborting some transaction' line to stdout. Under Atlas ingress rate-limit rejection storms this flooded the 64KB stdout pipe faster than the SSH channel drained it; all pool workers then blocked in pipe_write.

Keep the one-line warning (it already carries the full driver error string); print the traceback only when stop_on_error aborts the run.

Before change [logs](https://parsley.corp.mongodb.com/evergreen/sys_perf_mongotune_perf_atlas_real_no_ec.availability.arm.aws_tpcc_majority_small_with_load_patch_9b532a1fff589415f3e6144e3f24ce244fc8ca57_6a9fe0ed236bf40007751e2e_26_09_08_10_18_26/0/task?bookmarks=0,1137799)
After change [logs](https://parsley.corp.mongodb.com/evergreen/sys_perf_mongotune_perf_atlas_real_no_ec.availability.arm.aws_tpcc_majority_small_with_load_patch_9b532a1fff589415f3e6144e3f24ce244fc8ca57_6aa288e17c076100074782cb_26_09_10_10_39_36/0/task?bookmarks=0,25742)

**Patch testing results:** 
https://spruce.corp.mongodb.com/version/6aa2881ed03f360007222215/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e142da3300071b8b06/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1d03f3600072224a3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1cd770d0007c43681/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1a5813a000767f683/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1483e920007a4e040/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1c01f67000700d84f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1149ac800078dec26/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e1fc4f2c0007d453c5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6aa288e17c076100074782cb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC